### PR TITLE
fix: mugshot registration and modular upload logic

### DIFF
--- a/server/mugshot.lua
+++ b/server/mugshot.lua
@@ -1,18 +1,11 @@
 local config = require('config')
-local saveBase64AsPng = config.mugshotsUpload == 'local' and require('server.upload.local') or nil
-local resourcePath = 'https://cfx-nui-' .. GetCurrentResourceName() .. '/web/assets/mugshots'
 
+local providerName = config.mugshotsUpload:lower()
+local success, uploadProvider = pcall(require, ('server.upload.%s'):format(providerName))
 
----@param url string
----@return boolean
-local function IsAllowedMugshotUrl(url)
-    if type(url) ~= 'string' or url == '' or not url:find('^https://') then return false end
-    local allowed = { 'https://r2.fivemanage.com', 'https://fivemanage.com' }
-    for i = 1, #allowed do
-        local origin = allowed[i]
-        if origin and #url >= #origin and url:sub(1, #origin) == origin then return true end
-    end
-    return false
+if not success or not uploadProvider then
+    warn(('Failed to load upload provider: %s'):format(providerName))
+    uploadProvider = nil
 end
 
 ---@param src integer
@@ -20,22 +13,12 @@ end
 ---@param itemName string
 ---@return string|nil mugShotUrl
 local function resolveMugShot(src, identifier, itemName)
+    if not uploadProvider then return nil end
+
     local result = lib.callback.await('um-idcard:client:callBack:getMugShot', src)
     if not result then return nil end
 
-    if config.mugshotsUpload == 'fivemanage' and result.url then
-        if not IsAllowedMugshotUrl(result.url) then return nil end
-        return result.url
-    end
-
-    if config.mugshotsUpload == 'local' and result.base64 and saveBase64AsPng then
-        local imageName = ('%s_%s'):format(identifier, itemName)
-        if saveBase64AsPng(result.base64, imageName) then
-            return ('%s/%s.png'):format(resourcePath, imageName)
-        end
-    end
-
-    return nil
+    return uploadProvider(result, identifier, itemName)
 end
 
 function UpdateMugShot(src, item)

--- a/server/upload/fivemanage.lua
+++ b/server/upload/fivemanage.lua
@@ -30,7 +30,21 @@ local function GetPresignedUrl()
     return presignedUrl
 end
 
+---@param result table
+---@return string | nil
+local function IsAllowedMugshotUrl(result)
+    local url = result.url
+    if not url or type(url) ~= 'string' or url == '' or not url:find('^https://') then return nil end
+    local allowed = { 'https://r2.fivemanage.com', 'https://fivemanage.com' }
+    for i = 1, #allowed do
+        local origin = allowed[i]
+        if origin and #url >= #origin and url:sub(1, #origin) == origin then return url end
+    end
+    return nil
+end
 
 lib.callback.register('um-idcard:server:getPresignedUrl', function(source)
     return GetPresignedUrl()
 end)
+
+return IsAllowedMugshotUrl

--- a/server/upload/local.lua
+++ b/server/upload/local.lua
@@ -35,21 +35,28 @@ local function validateAndDecode(base64String)
     return decoded
 end
 
-local function saveBase64AsPng(base64String, imageName)
-    local decodedData = validateAndDecode(base64String)
-    if not decodedData then return false end
+---@param result table
+---@param identifier string
+---@param itemName string
+---@return string | nil
+local function saveBase64AsPng(result, identifier, itemName)
+    if not result.base64 then return nil end
 
+    local decodedData = validateAndDecode(result.base64)
+    if not decodedData then return nil end
+
+    local imageName = ('%s_%s'):format(identifier, itemName)
     imageName = imageName:gsub('[/\\%.%:%*%?%"%<%>%|]', '_')
 
     local updatedPath = resourcePath:match("resources/.*")
-    if not updatedPath then return false end
+    if not updatedPath then return nil end
     local file = io.open(('%s/%s/%s.png'):format(updatedPath, imagePath, imageName), "wb")
     if file then
         file:write(decodedData)
         file:close()
-        return true
+        return ('https://cfx-nui-%s/%s/%s.png'):format(cache.resource, imagePath, imageName)
     end
-    return false
+    return nil
 end
 
 return saveBase64AsPng


### PR DESCRIPTION
This refactor fixes a critical issue where server/upload/fivemanage.lua was not being loaded by the resource, resulting in the following error during NUI callbacks:

`error during NUI callback requestPresignedUrl: @ox_lib/imports/callback/client.lua:84: callback 'um-idcard:server:getPresignedUrl' does not exist`

Beyond the fix, the new unified provider system offers several long-term benefits:

- Scalability: New upload methods can now be added by simply creating a new provider file without touching the core logic.
- Separation of Concerns: Keeps provider-specific logic (like FiveManage URL validation or local Base64 decoding) encapsulated in the correct place.
- Code Readability: The main mugshot.lua is now significantly cleaner, delegating data handling to the providers and focusing solely on the workflow.